### PR TITLE
updates BME and other SPI devices to use old pigpio spi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,38 +126,19 @@
             <artifactId>pi4j-core</artifactId>
             <version>${pi4j.version}</version>
         </dependency>
-        <!--dependency>
+        <dependency>
             <groupId>com.pi4j</groupId>
             <artifactId>pi4j-plugin-pigpio</artifactId>
             <version>${pi4j.version}</version>
-        </dependency-->
+        </dependency>
         <!--- log4j version 2   -->
-        <!--dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.1</version>
-        </dependency-->
+
         <!-- include Pi4J Plugins (Platforms and I/O Providers) -->
         <dependency>
             <groupId>com.pi4j</groupId>
             <artifactId>pi4j-plugin-raspberrypi</artifactId>
             <version>${pi4j.version}</version>
         </dependency>
-        <!--dependency>
-            <groupId>com.pi4j</groupId>
-            <artifactId>pi4j-plugin-pigpio</artifactId>
-            <version>${pi4j.version}</version>
-        </dependency-->
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>

--- a/src/main/java/com/pi4j/devices/ads1256/ADS1256.java
+++ b/src/main/java/com/pi4j/devices/ads1256/ADS1256.java
@@ -173,7 +173,7 @@ public class ADS1256 {
                 .flags(0b0000000000000011100001L)  // Ux CE not used, MM mode 1
                 .baud(976563) //Spi.DEFAULT_BAUD)
                 .mode(SpiMode.MODE_1)
-                .provider("linuxfsspi")
+                .provider("pigpio-spi")
                 .build();
         this.spi = this.pi4j.create(spiConfig);
 

--- a/src/main/java/com/pi4j/devices/bme280/BME280DeviceSPI.java
+++ b/src/main/java/com/pi4j/devices/bme280/BME280DeviceSPI.java
@@ -139,7 +139,7 @@ public class BME280DeviceSPI {
                 .chipSelect(chipSelect)
                 .baud(Spi.DEFAULT_BAUD)
                 .mode(SpiMode.MODE_0)
-                .provider("linuxfsspi")
+                .provider("pigpio-spi")
                 .build();
         spi = pi4j.create(spiConfig);
 

--- a/src/main/java/com/pi4j/devices/bme280/README.md
+++ b/src/main/java/com/pi4j/devices/bme280/README.md
@@ -2,10 +2,19 @@
 https://pdf1.alldatasheet.com/datasheet-pdf/view/1132060/BOSCH/BME280.html
 
 
-The SPI example assumes SPI bus 0, ChipSelect GPIO 21. The GPIO is configurable as a program parm option.
+
 
 The program uses org.slf4j.simple Class SimpleLogger as suggested by the Pi4j_V2 documentation. Consult that logger
 class documentation to understand its various logging options.
+
+I2C connection path.
+1. mvn clean package
+2. cd target/distribution
+3. sudo ./runBME280I2C.sh
+Args if bus and or address must be set
+   -b 0x01 -a 0x77
+
+The SPI example assumes SPI bus 0, ChipSelect GPIO 21. The GPIO is configurable as a program parm option.
 
 The SPI connection per the Datasheet supports MODE0 or MODE3.  The spec shows reading a register consists of:
 1. Chip select driven low
@@ -22,7 +31,7 @@ GPIO as the CS (chip select)
 SPI connection path.
 1. mvn clean package
 2. cd target/distribution
-3. sudo ./runBMP280SPI.sh -csp 21
+3. sudo ./runBME280SPI.sh -csp 21
 
 
 

--- a/src/main/java/com/pi4j/devices/bmp280/BMP280DeviceSPI.java
+++ b/src/main/java/com/pi4j/devices/bmp280/BMP280DeviceSPI.java
@@ -139,7 +139,7 @@ public class BMP280DeviceSPI extends BMP280Device {
                 // .flags(0b0000000000000000100000L)  // MODE0, ux GPIO not used for chip select
                 .baud(Spi.DEFAULT_BAUD)    // Max 10MHz
                 .mode(SpiMode.MODE_0)
-                .provider("linuxfsspi")
+                .provider("pigpio-spi")
                 .build();
         this.spi = this.pi4j.create(spiConfig);
         this.logger.info("Exit:createSPIDevice  ");

--- a/src/main/java/com/pi4j/devices/bmp280/README.md
+++ b/src/main/java/com/pi4j/devices/bmp280/README.md
@@ -16,6 +16,16 @@ class documentation to understand its various logging options.
 
 The I2C connection functions as written in the Phillips spec.
 
+
+I2C connection path.
+1. mvn clean package
+2. cd target/distribution
+3. sudo ./runBMP280I2C.sh
+   Args if bus and or address must be set
+   -b 0x01 -a 0x77
+
+
+
 The SPI connection per the Datasheet supports MODE0 or MODE3.  The spec shows reading a register consists of:
 1. Chip select driven low 
 2. Eight clocks pulses to write the register address via the Pi MOSI
@@ -29,10 +39,6 @@ the chips config register be modified. As most chips use 4-wire configuration I 
 GPIO as the CS (chip select)
 
 
-I2C connection path.
-1. mvn clean package
-2. cd target/distribution
-3. sudo ./runBMP280I2C.sh
 
 SPI connection path.
 1. mvn clean package

--- a/src/main/java/com/pi4j/devices/dac8552/DAC8552.java
+++ b/src/main/java/com/pi4j/devices/dac8552/DAC8552.java
@@ -163,7 +163,7 @@ public class DAC8552 {
                 .flags(0b0000000000000011100001L)  // Ux CE not used, MM mode 1
                 .baud(976563)
                 .mode(SpiMode.MODE_1)
-                .provider("linuxfsspi")
+                .provider("pigpio-spi")
                 .build();
         this.spi = this.pi4j.create(spiConfig);
 

--- a/src/main/java/com/pi4j/devices/mcp3008/MCP3008.java
+++ b/src/main/java/com/pi4j/devices/mcp3008/MCP3008.java
@@ -40,7 +40,7 @@ public class MCP3008 {
                 .flags(0b0000000000000000000000L)
                 .baud(Spi.DEFAULT_BAUD)
                 .mode(SpiMode.MODE_0)
-                .provider("linuxfsspi")
+                .provider("pigpio-spi")
                 .build();
         this.spi = this.pi4j.create(spiConfig);
 

--- a/src/main/java/com/pi4j/devices/neopixel94v/NeoPixel94V.java
+++ b/src/main/java/com/pi4j/devices/neopixel94v/NeoPixel94V.java
@@ -191,11 +191,11 @@ public class NeoPixel94V extends Component {
         return Spi.newConfigBuilder(pi4j)
                 .id("SPI" + 1)
                 .name("LED Matrix")
-                .bus(SpiBus.BUS_0)
+                .bus(SpiBus.BUS_1)
                 .address(channel)
                 .mode(SpiMode.MODE_0)
                 .baud(8 * DEFAULT_FREQUENCY_PI4) //     bit-banging from Bit to SPI-Byte
-                .provider("linuxfsspi")
+                .provider("pigpio-spi")
                 .build();
 
     }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -2,8 +2,8 @@ module com.pi4j.devices{
 
     // Pi4J MODULES
     requires com.pi4j;
-   // requires com.pi4j.plugin.pigpio;
-  //  requires com.pi4j.library.pigpio;
+    requires com.pi4j.plugin.pigpio;
+    requires com.pi4j.library.pigpio;
 
     // SLF4J MODULES   LOG4J
     requires org.slf4j;


### PR DESCRIPTION
SPI devices will use the OLD PIGPIO SPI provider on all machines, But, Pi5 does not currently have any usable SPI provider.  This provider is planned but no committed data 