### PR TITLE
Add HC-SR04 Ultrasonic Sensor Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following lists the currently supported devices within this project:
 * [BME280  Temperature, Pressure and Humidity Sensor (I2C & SPI)](src/main/java/com/pi4j/devices/bme280/README.md) (1)(3)
 * [DAC8552  16bit DAC  SPI connected](src/main/java/com/pi4j/devices/dac8552/README.md) (3)
 * [DHT22 Temp/Humidity sensor](src/main/java/com/pi4j/devices/dht22/README.md) (1)
+* [HC-SR04 Ultrasonic Sensor](src/main/java/com/pi4j/devices/hcsr04/README.md)
 * [Is31fl3731 matrix controller](src/main/java/com/pi4j/devices/is31Fl37Matrix/README.md) (1)
 * [MCP23008 drive and read chip GPIOs](src/main/java/com/pi4j/devices/mcp23008/README.md)
 * [MCP23008 and MCP23017 Pin monitoring (interrupt support)](src/main/java/com/pi4j/devices/mcp23xxxApplication/README.md)
@@ -37,7 +38,7 @@ The following lists the currently supported devices within this project:
 * [VL53L0X TimeOfFlight device](src/main/java/com/pi4j/devices/vl53L0X/README.md) (1)
 
 
- 
+
 (1): This package uses code within this repo and Pi4J
 (2): Requires 2.2.2-SNAPSHOT of Pi4j that supports i2c multibyte write/restart
 (3): SPI versions of the device uses Pigpio, cannot be used on Raspberry Pi5

--- a/assets/runHCSR04.sh
+++ b/assets/runHCSR04.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+#
+#
+#     *
+#     * -
+#     * #%L
+#     * **********************************************************************
+#     * ORGANIZATION  :  Pi4J
+#     * PROJECT       :  Pi4J :: EXTENSION
+#     * FILENAME      :  runHCSR04.sh
+#     *
+#     * This file is part of the Pi4J project. More information about
+#     * this project can be found here:  https://pi4j.com/
+#     * **********************************************************************
+#     * %%
+#     *   * Copyright (C) 2012 - 2024 Pi4J
+#      * %%
+#     *
+#     * Licensed under the Apache License, Version 2.0 (the "License");
+#     * you may not use this file except in compliance with the License.
+#     * You may obtain a copy of the License at
+#     *
+#     *      http://www.apache.org/licenses/LICENSE-2.0
+#     *
+#     * Unless required by applicable law or agreed to in writing, software
+#     * distributed under the License is distributed on an "AS IS" BASIS,
+#     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     * See the License for the specific language governing permissions and
+#     * limitations under the License.
+#     * #L%
+#     *
+#
+#
+#
+#
+
+# See README for details
+
+java --module-path . --module  com.pi4j.devices/com.pi4j.devices.hcsr04.HCSR04_App  $@

--- a/src/main/java/com/pi4j/devices/hcsr04/HCSR04.java
+++ b/src/main/java/com/pi4j/devices/hcsr04/HCSR04.java
@@ -33,7 +33,6 @@
  *
  *
  */
-
 package com.pi4j.devices.hcsr04;
 
 import com.pi4j.context.Context;
@@ -109,13 +108,15 @@ public class HCSR04 {
      *         measurement is invalid (out of range).
      */
     public double measureDistance() {
-        // Send TRIG signal for 10 microseconds
-        trigPin.high();
-        long trigStartTime = System.nanoTime();
-        while (System.nanoTime() - trigStartTime < TRIG_SIGNAL_DURATION_NANOS) {
-            // Busy-wait for 10 microseconds
+        try {
+            // Send TRIG signal for 10 microseconds
+            trigPin.high();
+            Thread.sleep(0, (int) TRIG_SIGNAL_DURATION_NANOS); // Sleep for 10 microseconds
+            trigPin.low();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return -1; // Exit measurement if interrupted
         }
-        trigPin.low();
 
         // Measure echo pulse duration
         long echoStartTime = waitForEchoSignal(true);
@@ -155,7 +156,7 @@ public class HCSR04 {
      * (from the HC-SR04 sensor) into a distance. The calculation is done in
      * centimeters and accounts for the round-trip of the signal (to the object and back).
      *
-     * @param pulseStartTime the start time of the echo pulse in nanosecondshcsr
+     * @param pulseStartTime the start time of the echo pulse in nanoseconds
      * @param pulseEndTime the end time of the echo pulse in nanoseconds
      * @return the calculated distance to the object in centimeters, or -1 if the
      *         pulse duration is outside expected bounds (handled in measureDistance).

--- a/src/main/java/com/pi4j/devices/hcsr04/HCSR04.java
+++ b/src/main/java/com/pi4j/devices/hcsr04/HCSR04.java
@@ -1,0 +1,167 @@
+/*
+ *
+ *
+ *     *
+ *     * -
+ *     * #%L
+ *     * **********************************************************************
+ *     * ORGANIZATION  :  Pi4J
+ *     * PROJECT       :  Pi4J :: EXTENSION
+ *     * FILENAME      :  HCSR04.java
+ *     *
+ *     * This file is part of the Pi4J project. More information about
+ *     * this project can be found here:  https://pi4j.com/
+ *     * **********************************************************************
+ *     * %%
+ *     *   * Copyright (C) 2012 - 2024 Pi4J
+ *      * %%
+ *     *
+ *     * Licensed under the Apache License, Version 2.0 (the "License");
+ *     * you may not use this file except in compliance with the License.
+ *     * You may obtain a copy of the License at
+ *     *
+ *     *      http://www.apache.org/licenses/LICENSE-2.0
+ *     *
+ *     * Unless required by applicable law or agreed to in writing, software
+ *     * distributed under the License is distributed on an "AS IS" BASIS,
+ *     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     * See the License for the specific language governing permissions and
+ *     * limitations under the License.
+ *     * #L%
+ *     *
+ *
+ *
+ *
+ */
+
+package com.pi4j.devices.hcsr04;
+
+import com.pi4j.context.Context;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.io.gpio.digital.PullResistance;
+
+import java.time.Duration;
+
+/**
+ * A class to interface with the HC-SR04 ultrasonic distance sensor, allowing
+ * distance measurements by calculating the time taken for an ultrasonic pulse
+ * to travel to an object and back.
+ *
+ * <p>This class uses the Pi4J library to control the GPIO pins of a Raspberry Pi.
+ * It configures one pin as a trigger (output) and another as an echo (input) to
+ * measure distance based on the duration of the echo pulse.
+ */
+public class HCSR04 {
+    private static final double SPEED_OF_SOUND = 342.25; // Speed of sound in meters per second at 18°C
+    private static final long TRIG_SIGNAL_DURATION_NANOS = 10_000; // Trigger duration of 10 microseconds
+    private static final Duration MIN_ECHO_DURATION = Duration.ofNanos(150_000); // Minimum valid echo duration
+    private static final Duration MAX_ECHO_DURATION = Duration.ofMillis(25); // Maximum valid echo duration
+
+    private final DigitalOutput trigPin;
+    private final DigitalInput echoPin;
+
+    /**
+     * Constructs an HCSR04 object with the specified GPIO pin numbers for trigger and echo.
+     *
+     * @param pi4jContext the Pi4J context used to initialize GPIO pins
+     * @param trigPinNumber the GPIO pin number used for the trigger signal
+     * @param echoPinNumber the GPIO pin number used for the echo signal
+     */
+    public HCSR04(Context pi4jContext, int trigPinNumber, int echoPinNumber) {
+        var trigConfig = DigitalOutput.newConfigBuilder(pi4jContext)
+            .id("trigSignal")
+            .name("Trig signal for HC-SR04")
+            .address(trigPinNumber)
+            .shutdown(DigitalState.LOW)
+            .initial(DigitalState.LOW);
+        this.trigPin = pi4jContext.create(trigConfig);
+
+        var echoConfig = DigitalInput.newConfigBuilder(pi4jContext)
+            .id("echoSignal")
+            .name("Echo signal for HC-SR04")
+            .address(echoPinNumber)
+            .pull(PullResistance.PULL_DOWN);
+        this.echoPin = pi4jContext.create(echoConfig);
+    }
+
+    /**
+     * Alternative constructor that accepts pre-configured DigitalOutput and DigitalInput pins.
+     *
+     * @param trigPin the DigitalOutput instance for the trigger signal
+     * @param echoPin the DigitalInput instance for the echo signal
+     */
+    public HCSR04(DigitalOutput trigPin, DigitalInput echoPin) {
+        this.trigPin = trigPin;
+        this.echoPin = echoPin;
+    }
+
+    /**
+     * Measures the distance to an object by sending an ultrasonic pulse and measuring the
+     * time taken for the pulse to return. The result is returned in centimeters.
+     *
+     * <p>This method sends a 10-microsecond pulse on the trigger pin and then measures
+     * the duration of the echo pulse on the echo pin. The distance is calculated based
+     * on the duration of the echo pulse.
+     *
+     * @return the calculated distance to the object in centimeters, or -1 if the
+     *         measurement is invalid (out of range).
+     */
+    public double measureDistance() {
+        // Send TRIG signal for 10 microseconds
+        trigPin.high();
+        long trigStartTime = System.nanoTime();
+        while (System.nanoTime() - trigStartTime < TRIG_SIGNAL_DURATION_NANOS) {
+            // Busy-wait for 10 microseconds
+        }
+        trigPin.low();
+
+        // Measure echo pulse duration
+        long echoStartTime = waitForEchoSignal(true);
+        long echoEndTime = waitForEchoSignal(false);
+
+        // Calculate pulse duration
+        long pulseDuration = echoEndTime - echoStartTime;
+
+        // Check if pulse duration is within the expected range
+        if (pulseDuration >= MIN_ECHO_DURATION.toNanos() && pulseDuration <= MAX_ECHO_DURATION.toNanos()) {
+            return calculateDistance(echoStartTime, echoEndTime);
+        } else {
+            return -1; // Return -1 for out-of-range or invalid readings
+        }
+    }
+
+    /**
+     * Waits for the echo signal to either go high or low, depending on the specified parameter.
+     *
+     * <p>This method implements a busy-wait with a timeout to prevent infinite waiting.
+     *
+     * @param high {@code true} to wait for the echo signal to go high, {@code false} to wait for it to go low
+     * @return the time in nanoseconds when the echo signal changed, or the current time if timed out
+     */
+    private long waitForEchoSignal(boolean high) {
+        long timeoutStart = System.nanoTime();
+        while ((echoPin.isHigh() != high) && Duration.ofNanos(System.nanoTime() - timeoutStart).compareTo(MAX_ECHO_DURATION) < 0) {
+            // Busy-wait until signal changes or timeout
+        }
+        return System.nanoTime();
+    }
+
+    /**
+     * Calculates the distance to an object based on the duration of the echo pulse.
+     *
+     * <p>This method uses the speed of sound to convert the measured pulse duration
+     * (from the HC-SR04 sensor) into a distance. The calculation is done in
+     * centimeters and accounts for the round-trip of the signal (to the object and back).
+     *
+     * @param pulseStartTime the start time of the echo pulse in nanosecondshcsr
+     * @param pulseEndTime the end time of the echo pulse in nanoseconds
+     * @return the calculated distance to the object in centimeters, or -1 if the
+     *         pulse duration is outside expected bounds (handled in measureDistance).
+     */
+    private double calculateDistance(long pulseStartTime, long pulseEndTime) {
+        long pulseDuration = pulseEndTime - pulseStartTime; // Duration in nanoseconds
+        return pulseDuration * (SPEED_OF_SOUND / 10_000_000 / 2); // Directly in centimeters
+    }
+}

--- a/src/main/java/com/pi4j/devices/hcsr04/HCSR04_App.java
+++ b/src/main/java/com/pi4j/devices/hcsr04/HCSR04_App.java
@@ -1,0 +1,100 @@
+/*
+ *
+ *
+ *     *
+ *     * -
+ *     * #%L
+ *     * **********************************************************************
+ *     * ORGANIZATION  :  Pi4J
+ *     * PROJECT       :  Pi4J :: EXTENSION
+ *     * FILENAME      :  HCSR04_App.java
+ *     *
+ *     * This file is part of the Pi4J project. More information about
+ *     * this project can be found here:  https://pi4j.com/
+ *     * **********************************************************************
+ *     * %%
+ *     *   * Copyright (C) 2012 - 2024 Pi4J
+ *      * %%
+ *     *
+ *     * Licensed under the Apache License, Version 2.0 (the "License");
+ *     * you may not use this file except in compliance with the License.
+ *     * You may obtain a copy of the License at
+ *     *
+ *     *      http://www.apache.org/licenses/LICENSE-2.0
+ *     *
+ *     * Unless required by applicable law or agreed to in writing, software
+ *     * distributed under the License is distributed on an "AS IS" BASIS,
+ *     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     * See the License for the specific language governing permissions and
+ *     * limitations under the License.
+ *     * #L%
+ *     *
+ *
+ *
+ *
+ */
+
+package com.pi4j.devices.hcsr04;
+
+import com.pi4j.Pi4J;
+
+import com.pi4j.context.Context;
+import com.pi4j.util.Console;
+
+/**
+ * A simple application to test the HC-SR04 ultrasonic sensor by repeatedly measuring
+ * and printing the distance to the console.
+ *
+ * <p>This application uses the Pi4J library to interact with the GPIO pins on
+ * a Raspberry Pi, and it outputs distance measurements in centimeters every second.
+ */
+public class HCSR04_App {
+
+    // GPIO pins for the HC-SR04 sensor
+    private static final int TRIG = 23;
+    private static final int ECHO = 24;
+
+    /**
+     * Main method to initialize the Pi4J context, configure the HC-SR04 sensor, and
+     * continuously measure and display the distance.
+     *
+     * @param args command line arguments (not used)
+     * @throws Exception if an error occurs during measurement
+     */
+    public static void main(String[] args) throws Exception {
+        // Create Pi4J console wrapper/helper
+        final var console = new Console();
+
+        // Initialize Pi4J context
+        Context pi4j = Pi4J.newAutoContext();
+
+        // Initialize the HCSR04 sensor with specified GPIO pins
+        HCSR04 hcsr04 = new HCSR04(pi4j, TRIG, ECHO);
+
+        // Register a shutdown hook to release resources when the program exits
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            pi4j.shutdown();
+            console.println("Application has been stopped. Pi4J resources released.");
+        }));
+
+        System.out.println("Starting HC-SR04 distance measurement application...");
+
+        // Continuous loop to measure and display distance
+        while (true) {
+            try {
+                double distance = hcsr04.measureDistance();
+                if (distance >= 0) {
+                    console.println("Distance: %.2f cm%n", distance);
+                } else {
+                    console.println("Out of range or invalid reading.");
+                }
+            } catch (Exception e) {
+                console.println("Error during measurement: " + e.getMessage());
+            }
+
+            // Wait for 1 second before the next measurement
+            Thread.sleep(1000);
+        }
+    }
+}
+

--- a/src/main/java/com/pi4j/devices/hcsr04/README.md
+++ b/src/main/java/com/pi4j/devices/hcsr04/README.md
@@ -23,11 +23,31 @@ Wiring
 
 Compile and Run
 ------
-
-1. `mvn clean install`
-2. `cd target/distribution`
-3. `sudo ./runHCSR04.sh`
-
+1. **Build the project:**
+    ```bash
+    mvn clean install
+    ```
+2. **Navigate to the distribution directory:**
+    ```bash
+    cd target/distribution
+   ```
+3. **Run the application with optional GPIO parameters:** 
+    ```bash
+    sudo ./runHCSR04.sh <TRIG_PIN> <ECHO_PIN>
+    ```
+#### Example Usage
+ - **Using Default GPIO Pins (TRIG=23, ECHO=24):**
+    ```bash
+    sudo ./runHCSR04.sh
+    ```
+ - **Specifying GPIO Pins (e.g., TRIG=20, ECHO=21):**
+    ```bash
+    sudo ./runHCSR04.sh 20 21
+    ```
+ - **Getting Help Information:**
+    ```bash
+    sudo ./runHCSR04.sh -h
+    ```
 Code Overview
 -------------
 

--- a/src/main/java/com/pi4j/devices/hcsr04/README.md
+++ b/src/main/java/com/pi4j/devices/hcsr04/README.md
@@ -1,0 +1,65 @@
+HC-SR04 Ultrasonic Sensor Example with Pi4J
+===========================================
+
+This project demonstrates how to use the HC-SR04 ultrasonic sensor with a Raspberry Pi via the Pi4J library to measure distances in centimeters. The application continuously measures and displays the distance from the sensor to an object every second.
+
+Requirements
+------------
+
+-   Raspberry Pi (any model with GPIO support)
+-   HC-SR04 Ultrasonic Sensor
+-   Pi4J library (version compatible with your Pi and Java setup)
+-   Java 11 or later
+
+Wiring
+------
+
+1.  **TRIG** (trigger) pin on the HC-SR04 sensor is connected to GPIO 23 on the Raspberry Pi.
+2.  **ECHO** (echo) pin on the HC-SR04 sensor is connected to GPIO 24 on the Raspberry Pi.
+3.  **VCC** pin on the HC-SR04 sensor is connected to the 5V power pin on the Raspberry Pi.
+4.  **GND** pin on the HC-SR04 sensor is connected to a ground (GND) pin on the Raspberry Pi.
+
+**Note**: Some Raspberry Pi models use 3.3V GPIO pins, so if needed, use a voltage divider to lower the ECHO signal voltage.
+
+Compile and Run
+------
+
+1. `mvn clean install`
+2. `cd target/distribution`
+3. `sudo ./runHCSR04.sh`
+
+Code Overview
+-------------
+
+### HCSR04 Class
+
+The `HCSR04` class configures the GPIO pins to interact with the sensor and provides a `measureDistance` method to calculate and return the distance to an object based on the duration of the ECHO pulse.
+
+Key points:
+
+-   **Trigger Signal**: A 10-microsecond pulse on the TRIG pin starts the measurement.
+-   **Echo Measurement**: The class measures the duration of the ECHO pulse to calculate the distance.
+-   **Distance Calculation**: Uses the speed of sound to convert pulse duration into centimeters.
+
+### HCSR04_App Class
+
+The `HCSR04_App` class is a simple application that initializes the Pi4J context and the `HCSR04` sensor instance. It enters a loop to repeatedly measure and print the distance to the console every second.
+
+Example Output
+--------------
+
+When running the application, you should see output similar to the following:
+
+```
+Starting HC-SR04 distance measurement application...
+Distance: 25.30 cm
+Distance: 24.95 cm
+Distance: 24.80 cm
+...
+```
+
+If the object is out of range or no reading is detected, the output will indicate an invalid reading:
+
+```
+Out of range or invalid reading.
+```

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -45,6 +45,7 @@ module com.pi4j.devices{
     exports com.pi4j.devices.pcf8574a_lcd1602a;
     exports com.pi4j.devices.mcp23017_lcd1602a;
     exports com.pi4j.devices.dht22;
+    exports com.pi4j.devices.hcsr04;
     exports com.pi4j.devices.ads1256;
     exports com.pi4j.devices.dac8552;
     exports com.pi4j.devices.mpl3115a2;


### PR DESCRIPTION
This PR introduces an example application demonstrating how to interface with the HC-SR04 ultrasonic sensor using the Pi4J library on a Raspberry Pi. The application measures distances and displays the results in centimeters.

Details in the README.md file.